### PR TITLE
extend tfc-agent iam policy and allow it to assume roles from main, pd-infra-tools, staging and prod aws accounts

### DIFF
--- a/tfc-agent-ecs/producer/main.tf
+++ b/tfc-agent-ecs/producer/main.tf
@@ -120,6 +120,12 @@ data "aws_iam_policy_document" "agent_assume_role_policy_definition" {
       identifiers = ["ecs-tasks.amazonaws.com"]
       type        = "Service"
     }
+    resources = [
+      "arn:aws:iam::${var.infra_tools_account_id}:role/tfc-onemedical-terraform_dev_role",
+      "arn:aws:iam::${var.main_account_id}:role/tfe-prod-master-iam_role",
+      "arn:aws:iam::${var.staging_account_id}:role/tfe-prod-staging-iam_role",
+      "arn:aws:iam::${var.production_account_id}:role/tfe-prod-production-iam_role"
+    ]
   }
 }
 

--- a/tfc-agent-ecs/producer/variables.tf
+++ b/tfc-agent-ecs/producer/variables.tf
@@ -78,3 +78,27 @@ locals {
     hc-internet-facing = "false" # true/false
   }
 }
+
+variable "infra_tools_account_id" {
+  description = "Account ID for pd-infra-tools AWS account"
+  default     = "299299379634"
+  type        = string
+}
+
+variable "main_account_id" {
+  description = "Account ID for pd-main AWS account"
+  default     = "193567999519"
+  type        = string
+}
+
+variable "staging_account_id" {
+  description = "Account ID for pd-staging AWS account"
+  default     = "433233631458"
+  type        = string
+}
+
+variable "production_account_id" {
+  description = "Account ID for pd-production AWS account"
+  default     = "791438786431"
+  type        = string
+}


### PR DESCRIPTION
similar to https://github.com/onemedical/terraform-aws-tfe/pull/222, in order to provision resources in different accounts `tfc-onemedical-ecs-tfc-agent-role` IAM role needs to assume IAM roles from main, pd-infra-tools, staging and production aws accounts.  