### PR TITLE
[agent iam] extend assume roles w/ pd-ml-staging and pd-ml-prod aws accounts

### DIFF
--- a/tfc-agent-ecs/producer/main.tf
+++ b/tfc-agent-ecs/producer/main.tf
@@ -124,7 +124,9 @@ data "aws_iam_policy_document" "agent_assume_role_policy_definition" {
       "arn:aws:iam::${var.infra_tools_account_id}:role/tfc-onemedical-terraform_dev_role",
       "arn:aws:iam::${var.main_account_id}:role/tfe-prod-master-iam_role",
       "arn:aws:iam::${var.staging_account_id}:role/tfe-prod-staging-iam_role",
-      "arn:aws:iam::${var.production_account_id}:role/tfe-prod-production-iam_role"
+      "arn:aws:iam::${var.production_account_id}:role/tfe-prod-production-iam_role",
+      "arn:aws:iam::${var.pd_ml_staging_account_id}:role/tfe-prod-pd-ml-staging-iam_role",
+      "arn:aws:iam::${var.pd_ml_production_account_id}:role/tfe-prod-pd-ml-production-iam_role"
     ]
   }
 }

--- a/tfc-agent-ecs/producer/variables.tf
+++ b/tfc-agent-ecs/producer/variables.tf
@@ -102,3 +102,15 @@ variable "production_account_id" {
   default     = "791438786431"
   type        = string
 }
+
+variable "pd_ml_staging_account_id" {
+  description = "Account ID for pd-ml-staging AWS account"
+  default     = "213676009675"
+  type        = string
+}
+
+variable "pd_ml_production_account_id" {
+  description = "Account ID for pd-ml-production AWS account"
+  default     = "602771406891"
+  type        = string
+}


### PR DESCRIPTION
extending TFC agent role policy w/ ability to assume 2 ml aws accounts: `pd-ml-staging` and `pd-ml-production`. ML team will be moving(or maybe started) to experiment/move some the TFE workspaces into TFC